### PR TITLE
Stream compression

### DIFF
--- a/keyvi/src/cpp/compression/compression_strategy.h
+++ b/keyvi/src/cpp/compression/compression_strategy.h
@@ -85,7 +85,8 @@ struct RawCompressionStrategy final : public CompressionStrategy {
 
   static std::ostream& DoCompress(std::ostream& os,
                                   const char* raw, size_t raw_size) {
-    os << static_cast<char>(NO_COMPRESSION) << std::string(raw, raw_size);
+    os << static_cast<char>(NO_COMPRESSION);
+    os.write(raw, raw_size);
     return os;
   }
 

--- a/keyvi/src/cpp/compression/compression_strategy.h
+++ b/keyvi/src/cpp/compression/compression_strategy.h
@@ -89,7 +89,7 @@ struct RawCompressionStrategy final : public CompressionStrategy {
     return os;
   }
 
-  static std::string DoCompress(const char* raw, size_t raw_size) {
+  static inline std::string DoCompress(const char* raw, size_t raw_size) {
     std::ostringstream ss;
     DoCompress(ss, raw, raw_size);
     return ss.str();

--- a/keyvi/src/cpp/compression/snappy_compression_strategy.h
+++ b/keyvi/src/cpp/compression/snappy_compression_strategy.h
@@ -35,15 +35,18 @@ namespace compression {
 
 /** A compression strategy that wraps snappy. */
 struct SnappyCompressionStrategy final : public CompressionStrategy {
-  inline std::string Compress(const char* raw, size_t raw_size) {
-    return DoCompress(raw, raw_size);
+  inline std::ostream& Compress(std::ostream& os,
+                                const char* raw, size_t raw_size) {
+    return DoCompress(os, raw, raw_size);
   }
 
-  static std::string DoCompress(const char* raw, size_t raw_size) {
+  static std::ostream& DoCompress(std::ostream& os,
+                                  const char* raw, size_t raw_size) {
+    os << static_cast<char>(SNAPPY_COMPRESSION);
     std::string compressed;
     snappy::Compress(raw, raw_size, &compressed);
-
-    return std::string(1, static_cast<char>(SNAPPY_COMPRESSION)) + compressed;
+    os << compressed;
+    return os;
   }
 
   inline std::string Decompress(const std::string& compressed) {

--- a/keyvi/src/cpp/compression/snappy_compression_strategy.h
+++ b/keyvi/src/cpp/compression/snappy_compression_strategy.h
@@ -26,6 +26,7 @@
 #define SNAPPY_COMPRESSION_STRATEGY_H_
 
 #include <string>
+#include <sstream>
 #include <snappy.h>
 
 #include "compression/compression_strategy.h"
@@ -38,6 +39,12 @@ struct SnappyCompressionStrategy final : public CompressionStrategy {
   inline std::ostream& Compress(std::ostream& os,
                                 const char* raw, size_t raw_size) {
     return DoCompress(os, raw, raw_size);
+  }
+
+  static inline std::string DoCompress(const char* raw, size_t raw_size) {
+    std::ostringstream ss;
+    DoCompress(ss, raw, raw_size);
+    return ss.str();
   }
 
   static std::ostream& DoCompress(std::ostream& os,

--- a/keyvi/src/cpp/compression/zlib_compression_strategy.h
+++ b/keyvi/src/cpp/compression/zlib_compression_strategy.h
@@ -61,7 +61,7 @@ struct ZlibCompressionStrategy final : public CompressionStrategy {
 
       if (written  < zs.total_out) {
         // append the block to the output string
-        os << std::string(zlib_buffer_, zs.total_out - written);
+        os.write(zlib_buffer_, zs.total_out - written);
         written = zs.total_out;
       }
     } while (ret == Z_OK);

--- a/keyvi/src/cpp/compression/zlib_compression_strategy.h
+++ b/keyvi/src/cpp/compression/zlib_compression_strategy.h
@@ -38,7 +38,7 @@ struct ZlibCompressionStrategy final : public CompressionStrategy {
   ZlibCompressionStrategy(int compression_level = Z_BEST_COMPRESSION)
     : compression_level_(compression_level) {}
 
-  std::string Compress(const char* raw, size_t raw_size) {
+  std::ostream& Compress(std::ostream& os, const char* raw, size_t raw_size) {
     z_stream zs;                        // z_stream is zlib's control structure
     memset(&zs, 0, sizeof(zs));
 
@@ -49,7 +49,8 @@ struct ZlibCompressionStrategy final : public CompressionStrategy {
     zs.avail_in = raw_size;           // set the z_stream's input
 
     int ret;
-    std::string outstring(1, static_cast<char>(ZLIB_COMPRESSION));
+    size_t written = 0;
+    os << static_cast<char>(ZLIB_COMPRESSION);
 
     // retrieve the compressed bytes blockwise
     do {
@@ -58,9 +59,10 @@ struct ZlibCompressionStrategy final : public CompressionStrategy {
 
       ret = deflate(&zs, Z_FINISH);
 
-      if (outstring.size() - 1  < zs.total_out) {
+      if (written  < zs.total_out) {
         // append the block to the output string
-        outstring.append(zlib_buffer_, zs.total_out - outstring.size() + 1);
+        os << std::string(zlib_buffer_, zs.total_out - written);
+        written = zs.total_out;
       }
     } while (ret == Z_OK);
 
@@ -72,7 +74,7 @@ struct ZlibCompressionStrategy final : public CompressionStrategy {
       throw(std::runtime_error(oss.str()));
     }
 
-    return outstring;
+    return os;
   }
 
   inline std::string Decompress(const std::string& compressed) {

--- a/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
@@ -123,8 +123,8 @@ inline std::string EncodeJsonValue(
 inline std::string EncodeJsonValue(const std::string& raw_value,
                                    size_t compression_threshold=32) {
   msgpack::sbuffer msgpack_buffer;
-  return EncodeJsonValue(&compression::SnappyCompressionStrategy::DoCompress,
-                         &compression::RawCompressionStrategy::DoCompress,
+  return EncodeJsonValue(static_cast<std::string(const char*, size_t)>(&compression::SnappyCompressionStrategy::DoCompress),
+                         static_cast<std::string(const char*, size_t)>(&compression::RawCompressionStrategy::DoCompress),
                          msgpack_buffer, raw_value, compression_threshold);
 }
   

--- a/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
@@ -123,8 +123,10 @@ inline std::string EncodeJsonValue(
 inline std::string EncodeJsonValue(const std::string& raw_value,
                                    size_t compression_threshold=32) {
   msgpack::sbuffer msgpack_buffer;
-  return EncodeJsonValue(static_cast<std::string(const char*, size_t)>(&compression::SnappyCompressionStrategy::DoCompress),
-                         static_cast<std::string(const char*, size_t)>(&compression::RawCompressionStrategy::DoCompress),
+  return EncodeJsonValue(static_cast<std::string(*)(const char*, size_t)>(
+                          &compression::SnappyCompressionStrategy::DoCompress),
+                         static_cast<std::string(*)(const char*, size_t)>(
+                           &compression::RawCompressionStrategy::DoCompress),
                          msgpack_buffer, raw_value, compression_threshold);
 }
   


### PR DESCRIPTION
@hendrik-cliqz Implemented compression to streams. Please let me know if this is what you wanted, because it looks very ugly, lot of boilerplate code, and we don't even use it in `JsonValueStore` (and I am not even sure we could, because we do some juggling with the compressed string afterwards).