### PR TITLE
Building tools for Redhat Epel and Amazon Linux

### DIFF
--- a/contrib/build_boost_static.sh
+++ b/contrib/build_boost_static.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+wget http://sourceforge.net/projects/boost/files/boost/1.60.0/boost_1_60_0.tar.bz2
+
+tar xvfj boost_1_60_0.tar.bz2
+cd boost_1_60_0
+./bootstrap.sh
+./b2 cflags="-fPIC" --reconfigure
+./b2 cflags="-fPIC" --debug-building -a -d+2 -d+4 --build-dir $bd
+./b2 cflags="-fPIC" -d+2 -d+4 --build-dir $bd install
+./b2 install
+

--- a/contrib/build_snappy_static.sh
+++ b/contrib/build_snappy_static.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+wget https://github.com/google/snappy/releases/download/1.1.3/snappy-1.1.3.tar.gz
+tar xvfz snappy-1.1.3.tar.gz
+cd snappy-1.1.3
+./configure CFLAGS="-fPIC" CXXFLAGS="-fPIC"
+export CFLAGS="-fPIC"
+make
+sudo make install

--- a/contrib/prepare_amazon_linux_buildenv.sh
+++ b/contrib/prepare_amazon_linux_buildenv.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+sudo yum update -y
+sudo yum install -y gcc48-c++.x86_64 gcc44.x86_64
+sudo yum install -y zlib-devel
+sudo yum install -y libicu-devel libicu
+sudo yum install -y compat-libicu4
+sudo yum install -y python27-Cython
+sudo yum install -y git
+sudo yum install -y scons cmake
+sudo yum install -y libquadmath libquadmath-devel
+sudo yum install -y libstdc++48-static libstdc++48-devel
+sudo yum install -y rpmdevtools

--- a/pykeyvi/MANIFEST.in
+++ b/pykeyvi/MANIFEST.in
@@ -1,0 +1,6 @@
+recursive-include autowrap_includes *.hpp
+recursive-include keyvi/src/cpp *.h
+recursive-include keyvi/3rdparty *.h
+recursive-include keyvi/3rdparty *.inl
+recursive-include keyvi/3rdparty *.hpp
+recursive-include keyvi/3rdparty *.a

--- a/pykeyvi/setup.py
+++ b/pykeyvi/setup.py
@@ -1,14 +1,18 @@
 from setuptools import setup, Extension
 from setuptools.command.install import install
 import distutils.command.build as _build
+import distutils.command.bdist_rpm as _bdist_rpm
 from Cython.Distutils import build_ext
 import os
 import sys
+import tempfile
 import pkg_resources
 
 # workaround for autwrap bug (includes incompatible boost)
 autowrap_data_dir = "autowrap_includes"
 
+# when packaging an rpm, do ln -s ../keyvi . and use the following line
+# dictionary_sources = os.path.abspath('keyvi')
 dictionary_sources = os.path.abspath('../keyvi')
 
 additional_compile_flags = []
@@ -37,18 +41,22 @@ if (sys.platform == 'darwin'):
 #########################
 # Custom 'build' command
 #########################
-class  build(_build.build):
 
-    user_options=_build.build.user_options + \
-        [('mode=',
+custom_user_options = [('mode=',
           None,
           "build mode."),
          ('staticlinkboost',
           None,
           "special mode to statically link boost."),
         ]
+
+
+class custom_opts:
+
+    parent = None
+
     def initialize_options(self):
-        _build.build.initialize_options(self)
+        self.parent.initialize_options(self)
         self.mode = 'release'
         self.staticlinkboost = False
         
@@ -95,7 +103,32 @@ class  build(_build.build):
             args = getattr(ext_m, 'extra_link_args') + extra_link_arguments
             setattr(ext_m, 'extra_link_args', args)
 
-        _build.build.run(self)
+        self.parent.run(self)
+
+
+class build(custom_opts, _build.build):
+    parent = _build.build
+    user_options = _build.build.user_options + custom_user_options
+
+
+class bdist_rpm(custom_opts, _bdist_rpm.bdist_rpm):
+    parent = _bdist_rpm.bdist_rpm
+    user_options = _bdist_rpm.bdist_rpm.user_options + custom_user_options
+
+    def run(self):
+        def_setup_call = "%s %s build" % (self.python, os.path.basename(sys.argv[0]))
+
+        if self.staticlinkboost:
+            def_setup_call += " --staticlinkboost"
+
+        def_setup_call += " --mode " + self.mode
+        with tempfile.NamedTemporaryFile(suffix="_pykeyvi_rpm") as tmp:
+            # Do stuff with tmp
+            tmp.write(def_setup_call)
+            tmp.flush()
+            self.build_script = tmp.name
+
+            self.parent.run(self)
 
 ext_modules = [Extension('pykeyvi',
                         include_dirs = [autowrap_data_dir,
@@ -113,20 +146,20 @@ ext_modules = [Extension('pykeyvi',
                         library_dirs = [os.path.join(dictionary_sources, '3rdparty/tpie/build/install/lib')],
                         libraries = linklibraries)]
 
-PACKAGE_NAME = 'pykeyvi'
+PACKAGE_NAME = 'python-keyvi'
 
 setup(
     name = PACKAGE_NAME,
-    version = '0.1.1',
+    version = '0.1.14',
     description = 'Python bindings for keyvi',
     author = 'Hendrik Muhs',
     author_email = 'hendrik.muhs@gmail.com',
     license="ASL 2.0",
-    cmdclass = {'build_ext': build_ext, 'build': build},
+    cmdclass = {'build_ext': build_ext, 'build': build, 'bdist_rpm': bdist_rpm},
     ext_modules = ext_modules,
     zip_safe = False,
     url = 'https://github.com/cliqz/keyvi',
-    download_url = 'https://github.com/cliqz/keyvi/tarball/v0.1',
+    download_url = 'https://github.com/cliqz/keyvi/tarball/v0.1.14',
     keywords = ['FST'],
     classifiers = [],
 )


### PR DESCRIPTION
This PR contains the foundation to build a package for Amazon Linux. That enables using keyvi in EMR on AWS.