### PR TITLE
Fix compilation for Ubuntu 16.04 (Xenial Xerus)

### DIFF
--- a/keyvi/README.md
+++ b/keyvi/README.md
@@ -2,14 +2,14 @@
 
 ## Compile
 
-You need scons, simple compile by typing 
+You need scons, simple compile by typing
 
     scons
-    
+
 That compiles the library in debug mode, to compile in release mode (required for the python extension):
 
     scons mode=release
-    
+
 ## Package
 
 To create a dpkg (debian/ubuntu package) run:
@@ -23,6 +23,10 @@ To create a dpkg (debian/ubuntu package) run:
 
 In addition to a working gcc build environment, install the following libraries, e.g. using apt: boost (dev packages, at least version 1.54), scons, snappy, zlib, cmake.
 
+For example on Ubuntu (14.04 to 16.04) should install all the dependencies you need:
+
+    apt-get install cmake cython g++ libboost-all-dev libsnappy-dev libzzip-dev python-stdeb scons zlib1g-dev
+
 #### MAC
 
 In addtion to a working build setup (Xcode) install the following libraries using homebrew:
@@ -32,10 +36,10 @@ In addtion to a working build setup (Xcode) install the following libraries usin
     brew install snappy
     brew install lzlib
     brew install cmake
-    
+
 Now you should be able to compile as explained above.
-    
+
 For python-keyvi you need cython:
-    
+
     pip install cython
 

--- a/keyvi/SConstruct
+++ b/keyvi/SConstruct
@@ -51,7 +51,8 @@ linklibraries =  [ "tpie",
    "boost_regex",
    "boost_thread",
    "z",
-   "snappy"
+   "snappy",
+   "pthread"
    ]
 
 if buildmode == 'coverage':


### PR DESCRIPTION
Hi,

Here is a small patch to make `keyvi` compile on *Ubuntu 16.04 LTS* (which is to be released very soon).

Here is what happened when trying to compile it on Ubuntu 16.04 with `scons mode=release`:
```sh
g++ -o release/dictionaryfsa_unittests/dictionaryfsa_unittests tests/cpp/unit_tests_all.o tests/cpp/dictionary/dictionary_merger_test.o tests/cpp/dictionary/dictionary_compiler_test.o tests/cpp/dictionary/dictionary_test.o tests/cpp/dictionary/fsa/weighted_state_traverser_test.o tests/cpp/dictionary/fsa/generator_test.o tests/cpp/dictionary/fsa/entry_iterator_test.o tests/cpp/dictionary/fsa/automata_test.o tests/cpp/dictionary/fsa/state_traverser_test.o tests/cpp/dictionary/fsa/codepoint_state_traverser_test.o tests/cpp/dictionary/fsa/internal/sparse_array_persistence_test.o tests/cpp/dictionary/fsa/internal/string_value_store_test.o tests/cpp/dictionary/fsa/internal/lru_generation_cache_test.o tests/cpp/dictionary/fsa/internal/unpacked_state_stack_test.o tests/cpp/dictionary/fsa/internal/sparse_array_builder_test.o tests/cpp/dictionary/fsa/internal/memory_map_manager_test.o tests/cpp/dictionary/fsa/internal/sliding_window_bit_vector_position_tracker_test.o tests/cpp/dictionary/fsa/internal/packed_state_test.o tests/cpp/dictionary/fsa/internal/json_value_store_test.o tests/cpp/dictionary/fsa/internal/minimization_hash_test.o tests/cpp/dictionary/fsa/internal/bit_vector_test.o tests/cpp/dictionary/fsa/internal/unpacked_state_test.o tests/cpp/dictionary/fsa/traversal/near_traversal_test.o tests/cpp/dictionary/completion/prefix_completion_test.o tests/cpp/dictionary/util/md5_test.o tests/cpp/dictionary/util/transform_test.o tests/cpp/dictionary/util/bounded_priority_queue_test.o tests/cpp/dictionary/util/jump_consistent_hash_test.o tests/cpp/dictionary/util/single_producer_consumer_ringbuffer_test.o tests/cpp/dictionary/util/vint_test.o tests/cpp/stringdistance/levenshtein_test.o tests/cpp/stringdistance/needleman_wunsch_test.o tests/cpp/compression/fsa_predictive_compression_test.o tests/cpp/transform/fsa_transform_test.o -L3rdparty/tpie/build/install/lib -lboost_unit_test_framework -ltpie -lboost_program_options -lboost_iostreams -lboost_filesystem -lboost_system -lboost_regex -lz -lsnappy -lboost_thread
/usr/bin/ld: 3rdparty/tpie/build/install/lib/libtpie.a(job.cpp.o): undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
scons: *** [release/dictionaryfsa_unittests/dictionaryfsa_unittests] Error 1
scons: building terminated because of errors.
```

For some reason (that I didn't figure yet), `pthread` seems to be required here, even if on 14.04 it's not. So adding it to the list of dependencies solves the problem. (wild guess: maybe related to a newer version of `libboost_thread`?).

I also added an example command to the README to show how to install dependencies on Ubuntu.

Cheers,
Rémi
