### PR TITLE
Fix tmp compiler

### DIFF
--- a/keyvi/src/cpp/dictionary/dictionary_compiler.h
+++ b/keyvi/src/cpp/dictionary/dictionary_compiler.h
@@ -34,6 +34,7 @@
 #include "dictionary/fsa/internal/null_value_store.h"
 #include "dictionary/fsa/internal/serialization_utils.h"
 #include "dictionary/fsa/generator_adapter.h"
+#include "dictionary/fsa/internal/constants.h"
 
 //#define ENABLE_TRACING
 #include "dictionary/util/trace.h"
@@ -103,7 +104,12 @@ class DictionaryCompiler
       sorter_.set_available_memory(memory_limit);
       sorter_.begin();
 
-      value_store_= new ValueStoreT(params);
+      if (params_.count(TEMPORARY_PATH_KEY) == 0) {
+        params_[TEMPORARY_PATH_KEY] =
+            boost::filesystem::temp_directory_path().string();
+      }
+
+      value_store_= new ValueStoreT(params_);
     }
 
     ~DictionaryCompiler(){
@@ -205,7 +211,7 @@ class DictionaryCompiler
     util::TpieIntializer& initializer_;
     tpie::serialization_sorter<key_value_t> sorter_;
     size_t memory_limit_;
-    compiler_param_t params_;
+    fsa::internal::IValueStoreWriter::vs_param_t params_;
     ValueStoreT* value_store_;
     fsa::GeneratorAdapterInterface<PersistenceT, ValueStoreT>* generator_ = nullptr;
     bool sort_finalized_ = false;

--- a/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
@@ -140,7 +140,7 @@ class JsonValueStore final : public IValueStoreWriter {
 
     const RawPointerForCompare<MemoryMapManager> stp(string_buffer_.data(), string_buffer_.size(),
                                                      values_extern_);
-    const RawPointer p = hash_.Get(stp);
+    const RawPointer<> p = hash_.Get(stp);
 
     if (!p.IsEmpty()) {
       // found the same value again, minimize
@@ -155,7 +155,7 @@ class JsonValueStore final : public IValueStoreWriter {
     uint64_t pt = AddValue();
 
     TRACE("add value to hash at %d, length %d", pt, string_buffer_.size());
-    hash_.Add(RawPointer(pt, stp.GetHashcode(), string_buffer_.size()));
+    hash_.Add(RawPointer<>(pt, stp.GetHashcode(), string_buffer_.size()));
 
     return pt;
   }
@@ -205,7 +205,7 @@ class JsonValueStore final : public IValueStoreWriter {
   size_t compression_threshold_;
   bool minimize_ = true;
 
-  LeastRecentlyUsedGenerationsCache<RawPointer> hash_;
+  LeastRecentlyUsedGenerationsCache<RawPointer<>> hash_;
   compression::buffer_t string_buffer_;
   msgpack::sbuffer msgpack_buffer_;
   size_t number_of_values_ = 0;
@@ -226,7 +226,7 @@ class JsonValueStore final : public IValueStoreWriter {
 
      const RawPointerForCompare<MemoryMapManager> stp(buf_ptr, buffer_size,
                                                           values_extern_);
-     const RawPointer p = hash_.Get(stp);
+     const RawPointer<> p = hash_.Get(stp);
 
      if (!p.IsEmpty()) {
        // found the same value again, minimize
@@ -245,7 +245,7 @@ class JsonValueStore final : public IValueStoreWriter {
                                 full_buf_size);
      values_buffer_size_ += full_buf_size;
 
-     hash_.Add(RawPointer(pt, stp.GetHashcode(), buffer_size));
+     hash_.Add(RawPointer<>(pt, stp.GetHashcode(), buffer_size));
 
      return pt;
    }

--- a/keyvi/src/cpp/dictionary/fsa/internal/memory_map_manager.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/memory_map_manager.h
@@ -235,6 +235,7 @@ final {
     }
 
     void CreateMapping() {
+      TRACE("create new mapping %d", number_of_chunks_ + 1);
       mapping new_mapping;
 
       boost::filesystem::path filename = GetFilenameForChunk(number_of_chunks_);
@@ -253,7 +254,10 @@ final {
           filename.native().c_str(), boost::interprocess::read_write);
 
       new_mapping.region_ = new boost::interprocess::mapped_region(
-          *new_mapping.mapping_, boost::interprocess::read_write);
+          *new_mapping.mapping_, boost::interprocess::copy_on_write);
+
+      // prevent pre-fetching pages by the OS which does not make sense as values usually fit into few pages
+      new_mapping.region_->advise(boost::interprocess::mapped_region::advice_types::advice_random);
 
       mappings_.push_back(new_mapping);
       ++number_of_chunks_;

--- a/keyvi/src/cpp/dictionary/fsa/internal/memory_map_manager.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/memory_map_manager.h
@@ -260,7 +260,7 @@ final {
           filename.native().c_str(), boost::interprocess::read_write);
 
       new_mapping.region_ = new boost::interprocess::mapped_region(
-          *new_mapping.mapping_, boost::interprocess::copy_on_write);
+          *new_mapping.mapping_, boost::interprocess::read_write);
 
       // prevent pre-fetching pages by the OS which does not make sense as values usually fit into few pages
       new_mapping.region_->advise(boost::interprocess::mapped_region::advice_types::advice_random);

--- a/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
@@ -38,18 +38,19 @@ namespace dictionary {
 namespace fsa {
 namespace internal {
 
+template<class HashCodeTypeT = int32_t>
 struct RawPointer final {
    public:
     RawPointer() : RawPointer(0, 0, 0) {}
 
-    RawPointer(uint64_t offset, int hashcode, size_t length)
+    RawPointer(uint64_t offset, HashCodeTypeT hashcode, size_t length)
         : offset_(offset), hashcode_(hashcode), length_(length) {
       if (length > USHRT_MAX) {
         length_ = USHRT_MAX;
       }
     }
 
-    int GetHashcode() const {
+    HashCodeTypeT GetHashcode() const {
       return hashcode_;
     }
 
@@ -85,20 +86,20 @@ struct RawPointer final {
     static const size_t MaxCookieSize = 0xFFFF;
 
     uint64_t offset_;
-    int32_t hashcode_;
+    HashCodeTypeT hashcode_;
     ushort length_;
     ushort cookie_ = 0;
 
   };
 
-  template<class PersistenceT>
+  template<class PersistenceT, class HashCodeTypeT = int32_t>
   struct RawPointerForCompare final {
    public:
     RawPointerForCompare(const char* value, size_t value_size, PersistenceT* persistence)
         : value_(value), value_size_(value_size), persistence_(persistence) {
 
       // calculate a hashcode
-      int32_t h = 31;
+      HashCodeTypeT h = 31;
 
       for(size_t i = 0; i < value_size_; ++i) {
         h = (h * 54059) ^ (value[i] * 76963);
@@ -109,11 +110,11 @@ struct RawPointer final {
       hashcode_ = h;
     }
 
-    int GetHashcode() const {
+    HashCodeTypeT GetHashcode() const {
       return hashcode_;
     }
 
-    bool operator==(const RawPointer& l) const {
+    bool operator==(const RawPointer<>& l) const {
       TRACE("check equality, 1st hashcode");
 
       // First filter - check if hash code  is the same
@@ -148,7 +149,7 @@ struct RawPointer final {
     const char* value_;
     size_t value_size_;
     PersistenceT* persistence_;
-    int32_t hashcode_;
+    HashCodeTypeT hashcode_;
   };
 
 } /* namespace internal */

--- a/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
@@ -50,7 +50,7 @@ struct RawPointer final {
       }
     }
 
-    HashCodeTypeT GetHashcode() const {
+    int GetHashcode() const {
       return hashcode_;
     }
 
@@ -99,7 +99,7 @@ struct RawPointer final {
         : value_(value), value_size_(value_size), persistence_(persistence) {
 
       // calculate a hashcode
-      HashCodeTypeT h = 31;
+      int h = 31;
 
       for(size_t i = 0; i < value_size_; ++i) {
         h = (h * 54059) ^ (value[i] * 76963);
@@ -110,7 +110,7 @@ struct RawPointer final {
       hashcode_ = h;
     }
 
-    HashCodeTypeT GetHashcode() const {
+    int GetHashcode() const {
       return hashcode_;
     }
 

--- a/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
@@ -114,7 +114,7 @@ struct RawPointer final {
       return hashcode_;
     }
 
-    bool operator==(const RawPointer<>& l) const {
+    bool operator==(const RawPointer<HashCodeTypeT>& l) const {
       TRACE("check equality, 1st hashcode");
 
       // First filter - check if hash code  is the same

--- a/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/value_store_persistence.h
@@ -50,7 +50,7 @@ struct RawPointer final {
       }
     }
 
-    int GetHashcode() const {
+    HashCodeTypeT GetHashcode() const {
       return hashcode_;
     }
 
@@ -99,7 +99,7 @@ struct RawPointer final {
         : value_(value), value_size_(value_size), persistence_(persistence) {
 
       // calculate a hashcode
-      int h = 31;
+      HashCodeTypeT h = 31;
 
       for(size_t i = 0; i < value_size_; ++i) {
         h = (h * 54059) ^ (value[i] * 76963);
@@ -110,7 +110,7 @@ struct RawPointer final {
       hashcode_ = h;
     }
 
-    int GetHashcode() const {
+    HashCodeTypeT GetHashcode() const {
       return hashcode_;
     }
 

--- a/keyvi/tests/cpp/dictionary/fsa/internal/memory_map_manager_test.cpp
+++ b/keyvi/tests/cpp/dictionary/fsa/internal/memory_map_manager_test.cpp
@@ -188,6 +188,33 @@ BOOST_AUTO_TEST_CASE( Appendchunkoverflow ) {
   boost::filesystem::remove_all(path);
 }
 
+BOOST_AUTO_TEST_CASE( Persist ) {
+  size_t chunkSize = 4096;
+
+  boost::filesystem::path path = boost::filesystem::temp_directory_path();
+  path /= boost::filesystem::unique_path(
+      "dictionary-fsa-unittest-%%%%-%%%%-%%%%-%%%%");
+  boost::filesystem::create_directory(path);
+  MemoryMapManager m(chunkSize, path, "append large chunk test");
+
+  char buffer[4096];
+  std::fill(buffer, buffer+4096, 'x');
+  m.Append(buffer, 4096);
+  m.Append(buffer, 1);
+
+  m.Persist();
+
+  auto filename = path;
+  filename /= "out";
+  std::ofstream out_stream(filename.native(), std::ios::binary);
+  m.Write(out_stream, 0 );
+  BOOST_CHECK_EQUAL(4097, out_stream.tellp());
+  out_stream.close();
+
+  boost::filesystem::remove_all(path);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } /* namespace internal */

--- a/pykeyvi/tests/dictionary_compiler_test.py
+++ b/pykeyvi/tests/dictionary_compiler_test.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Usage: py.test tests
 
+import os
 import pykeyvi
 
 def test_compiler_no_compile_edge_case():
@@ -8,3 +9,19 @@ def test_compiler_no_compile_edge_case():
     c.Add("abc")
     c.Add("abd")
     del c
+
+def test_tmp_dir():
+    cwd = os.getcwd()
+    try:
+        os.mkdir("tmp_dir_test")
+        os.chdir(os.path.join(cwd, "tmp_dir_test"))
+        c = pykeyvi.JsonDictionaryCompiler()
+        c.Add("abc", "{'a':2}")
+        assert len(os.listdir('.')) == 0
+        c.Compile()
+        assert len(os.listdir('.')) == 0
+        del c
+        assert len(os.listdir('.')) == 0
+    finally:
+        os.chdir(cwd)
+        os.rmdir("tmp_dir_test")


### PR DESCRIPTION
This fixes a regression in the compiler not respecting the TMPDIR variable.

Apart from that: improving IO in case of high memory pressure by changing memory mapping to be private during compilation and disable readahead. Fixing a little type inconsistency.