### PR TITLE
Mac OS El Captain (clang-703.0.29) compile fix for tpie

### DIFF
--- a/keyvi/3rdparty/tpie/tpie/packed_array.h
+++ b/keyvi/3rdparty/tpie/tpie/packed_array.h
@@ -145,8 +145,7 @@ private:
 		storage_type * elms;
 		size_t index;
 	public:
-		template <bool> friend class packed_array::iter_base;
-		template <bool> friend class packed_array::const_iter_base;
+		template <typename, int> friend class packed_array;
 		operator T() const {return static_cast<T>((elms[high(index)] >> low(index))&mask());}
 	 	iter_return_type & operator=(const T b) {
 			storage_type * p = elms+high(index);


### PR DESCRIPTION
patched class `packed_array::iter_return_type` in order to compile on Mac OS El Captain