### PR TITLE
Travis OS X build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,14 @@ env:
 matrix:
   include:
     - os: osx
+      osx_image: xcode7
       compiler: clang
       env: BUILD_TYPE=osx
 
 before_install:
-  - pip install --upgrade pip
-  - pip install twine pytest msgpack-python
   - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./travis/setup_osx.sh ; fi
+  - pip install --upgrade pip
+  - sudo pip install twine pytest msgpack-python
   - if [ "$CC" = "gcc" ] && [ "$CONF" = "coverage" ]; then pip install coveralls-merge cpp-coveralls ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
   include:
     - os: osx
       compiler: clang
-      env:  BUILD_TYPE=linux      CONF=release  ARCH=x86_64
 
 before_install:
   - pip install --upgrade pip
@@ -76,6 +75,7 @@ script:
   - if [ "$BUILD_TYPE" == "linux" ]; then ./travis/build_linux.sh ; fi
   - if [ "$BUILD_TYPE" == "manylinux" ]; then ./travis/build_manylinux_package.sh ; fi
   - if [ "$BUILD_TYPE" == "sdist" ]; then ./travis/build_sdist_package.sh ; fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./travis/build_osx_package.sh ; fi
 
 after_success:
   - if [ "$CC" = "gcc-4.8" ] && [ "$CONF" = "coverage" ]; then ./travis/coverage.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
 before_install:
   - pip install --upgrade pip
   - pip install twine pytest msgpack-python
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./travis/setup_osx.sh ; fi
   - if [ "$CC" = "gcc" ] && [ "$CONF" = "coverage" ]; then pip install coveralls-merge cpp-coveralls ; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,12 @@ env:
     - GITHUB_REPO='cliqz-oss/keyvi'
     - secure: "cy3LYIeuSxIdDt4GArpStoawmlEXy7oVX/Z72hwcXVj6EgQ8za16GaayQCLbHy9Hlm0K42QmWg4s7iOm/QzKBlZAwvHMktmHIVoovXe+i83bRVclMr/zvzhEeSyCy4xbBEBT8qt4p0dwX4hOF6cfy+rpNsI+CMBbGgMSS/MZHm/FmF5fKqcZBJfZfEPOqOukID4NPirDlZ8Jmg8JR1K722+xXvwbSif0a6wJ3p517JjYJxO8a7AzdXJMXC3sJmpsSCBwp+NG9BrwJ/MgQFHKUEhPoPFOEI7P57rH9Cax8+y9j7ukwlB36Ae5ApddcXYbQMOtpoA+DvR5JbsbYWi4/T6qUntYmpRy5gPVD/IwIAldEt3iERswjWFHgUjN+JaJ6YqQHl5ks++NZbB6W8eqP2Id1Oa669b6uxFn62Ln43TcvY4bapJEscj7goReiQGjwIWjBxphP/eJaPae642HnpBijPjAG+uA8IyO2nuY/+xULMiNXDFGVmBC5VfYp95Y71ZlUpfUv6u96mXc3ruWmDRzGNNgNXmzIGfD5bxn2uxMykOW6ubG4mnxOT/qMia8yrYsPYdBsvc1u2XWHAUUrHPVr9HmFo68y3AfuXwXH2Eb0fGTxNmaihabcqoBdm6HRK3aRLqXweBI2xXyOY8Tf07hUy+G7qkg2ZrsEgwWg+k="  # COVERALLS_REPO_TOKEN
 
+matrix:
+  include:
+    - os: osx
+      compiler: clang
+      env:  BUILD_TYPE=linux      CONF=release  ARCH=x86_64
+
 before_install:
   - pip install --upgrade pip
   - pip install twine pytest msgpack-python

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
 matrix:
   include:
     - os: osx
-      osx_image: xcode7
+      osx_image: xcode7.1
       compiler: clang
       env: BUILD_TYPE=osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ matrix:
   include:
     - os: osx
       compiler: clang
+      env: BUILD_TYPE=osx
 
 before_install:
   - pip install --upgrade pip
@@ -75,7 +76,7 @@ script:
   - if [ "$BUILD_TYPE" == "linux" ]; then ./travis/build_linux.sh ; fi
   - if [ "$BUILD_TYPE" == "manylinux" ]; then ./travis/build_manylinux_package.sh ; fi
   - if [ "$BUILD_TYPE" == "sdist" ]; then ./travis/build_sdist_package.sh ; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then ./travis/build_osx_package.sh ; fi
+  - if [ "$BUILD_TYPE" == "osx" ]; then ./travis/build_osx_package.sh ; fi
 
 after_success:
   - if [ "$CC" = "gcc-4.8" ] && [ "$CONF" = "coverage" ]; then ./travis/coverage.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,8 @@ env:
 
 before_install:
   - pip install --upgrade pip
-  - pip install --user twine
-  - pip install --user --use-wheel --install-option="--no-cython-compile" cython
-  - pip install --user --use-wheel pytest
-  - pip install --user --use-wheel msgpack-python
-  - if [ "$CC" = "gcc" ] && [ "$CONF" = "coverage" ]; then pip install --user --use-wheel coveralls-merge; fi
-  - if [ "$CC" = "gcc" ] && [ "$CONF" = "coverage" ]; then pip install --user --use-wheel cpp-coveralls; fi
+  - pip install twine pytest msgpack-python
+  - if [ "$CC" = "gcc" ] && [ "$CONF" = "coverage" ]; then pip install coveralls-merge cpp-coveralls ; fi
 
 install:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi

--- a/travis/build_osx_package.sh
+++ b/travis/build_osx_package.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ev
+
+cd keyvi
+scons -j 4 mode=release
+cd ..
+
+cd pykeyvi
+python setup.py bdist_wheel -d wheelhouse
+pip install wheelhouse/*.whl
+py.test tests
+cd ..

--- a/travis/build_osx_package.sh
+++ b/travis/build_osx_package.sh
@@ -7,6 +7,6 @@ cd ..
 
 cd pykeyvi
 python setup.py bdist_wheel -d osx_wheel
-pip install osx_wheel/*.whl
+sudo pip install osx_wheel/*.whl
 py.test tests
 cd ..

--- a/travis/build_osx_package.sh
+++ b/travis/build_osx_package.sh
@@ -6,7 +6,7 @@ scons -j 4 mode=release
 cd ..
 
 cd pykeyvi
-python setup.py bdist_wheel -d wheelhouse
-pip install wheelhouse/*.whl
+python setup.py bdist_wheel -d osx_wheel
+pip install osx_wheel/*.whl
 py.test tests
 cd ..

--- a/travis/build_osx_package.sh
+++ b/travis/build_osx_package.sh
@@ -6,7 +6,7 @@ scons -j 4 mode=release
 cd ..
 
 cd pykeyvi
-python setup.py bdist_wheel -d osx_wheel
-sudo pip install osx_wheel/*.whl
+python setup.py bdist_wheel -d wheelhouse
+sudo pip install wheelhouse/*.whl
 py.test tests
 cd ..

--- a/travis/build_sdist_package.sh
+++ b/travis/build_sdist_package.sh
@@ -3,6 +3,6 @@ set -ev
 
 cd pykeyvi
 python setup.py sdist -d wheelhouse
-pip install wheelhouse/*.tar.gz
+sudo pip install wheelhouse/*.tar.gz
 py.test tests
 cd ..

--- a/travis/setup_osx.sh
+++ b/travis/setup_osx.sh
@@ -2,4 +2,4 @@
 set -ev
 
 brew update
-brew install snappy scons
+brew install snappy scons cmake

--- a/travis/setup_osx.sh
+++ b/travis/setup_osx.sh
@@ -3,3 +3,5 @@ set -ev
 
 brew update
 brew install snappy scons cmake
+sudo easy_install pip
+sudo pip install wheel

--- a/travis/setup_osx.sh
+++ b/travis/setup_osx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ev
+
+brew update
+brew install snappy scons
+
+brew uninstall boost
+wget 'https://github.com/hendrik-cliqz/travis-homebrew-bottle/releases/download/boost-1.61-cxx11/boost-1.61.0_1.mavericks.bottle.1.tar.gz'
+brew install boost-1.61.0_1.mavericks.bottle.1.tar.gz

--- a/travis/setup_osx.sh
+++ b/travis/setup_osx.sh
@@ -5,5 +5,6 @@ brew update
 brew install snappy scons
 
 brew uninstall boost
-wget 'https://github.com/hendrik-cliqz/travis-homebrew-bottle/releases/download/boost-1.61-cxx11/boost-1.61.0_1.mavericks.bottle.1.tar.gz'
-brew install boost-1.61.0_1.mavericks.bottle.1.tar.gz
+#wget 'https://github.com/hendrik-cliqz/travis-homebrew-bottle/releases/download/boost-1.61-cxx11/boost-1.61.0_1.mavericks.bottle.1.tar.gz'
+#brew install boost-1.61.0_1.mavericks.bottle.1.tar.gz
+brew install --force-bottles boost

--- a/travis/setup_osx.sh
+++ b/travis/setup_osx.sh
@@ -3,8 +3,3 @@ set -ev
 
 brew update
 brew install snappy scons
-
-brew uninstall boost
-#wget 'https://github.com/hendrik-cliqz/travis-homebrew-bottle/releases/download/boost-1.61-cxx11/boost-1.61.0_1.mavericks.bottle.1.tar.gz'
-#brew install boost-1.61.0_1.mavericks.bottle.1.tar.gz
-brew install --force-bottles boost

--- a/travis/upload_packages.sh
+++ b/travis/upload_packages.sh
@@ -3,5 +3,5 @@ set -ev
 
 cd pykeyvi
 if [ -n "$(ls -A wheelhouse)" ]; then
-    twine upload --config-file ../travis/pypirc -r pypitest -u $PYPI_USERNAME -p $PYPI_PASSWORD wheelhouse/*
+    twine upload --config-file ../travis/pypirc -u $PYPI_USERNAME -p $PYPI_PASSWORD wheelhouse/*
 fi


### PR DESCRIPTION
- added Mac OS builds on travis for OS X 10.10. Older versions are not supported by Apple anymore, so I think it's safe to have packages started from 10.10
- added static linkage for OS X wheels to have them portable