### PR TITLE
floating_point_precision option

### DIFF
--- a/keyvi/src/cpp/dictionary/fsa/internal/constants.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/constants.h
@@ -50,6 +50,7 @@
 #define COMPRESSION_KEY "compression"
 #define COMPRESSION_THRESHOLD_KEY "compression_threshold"
 #define MINIMIZATION_KEY "minimization"
+#define SINGLE_PRECISION_FLOAT_KEY "floating_point_precision"
 #define STABLE_INSERTS "stable_insert"
 
 

--- a/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/json_value_store.h
@@ -94,6 +94,11 @@ class JsonValueStore final : public IValueStoreWriter {
       minimize_ = false;
     }
 
+    if (parameters_.count(SINGLE_PRECISION_FLOAT_KEY) > 0 && parameters_[SINGLE_PRECISION_FLOAT_KEY] == "single") {
+      // set single precision float mode
+      msgpack_buffer_.set_single_precision_float();
+    }
+
     compressor_.reset(compression::compression_strategy(compressor));
     raw_compressor_.reset(compression::compression_strategy("raw"));
     // This is beyond ugly, but needed for EncodeJsonValue :(
@@ -208,7 +213,7 @@ class JsonValueStore final : public IValueStoreWriter {
 
   LeastRecentlyUsedGenerationsCache<RawPointer<>> hash_;
   compression::buffer_t string_buffer_;
-  msgpack::sbuffer msgpack_buffer_;
+  util::msgpack_buffer msgpack_buffer_;
   size_t number_of_values_ = 0;
   size_t number_of_unique_values_ = 0;
   size_t values_buffer_size_ = 0;

--- a/keyvi/src/cpp/dictionary/util/json_value.h
+++ b/keyvi/src/cpp/dictionary/util/json_value.h
@@ -32,8 +32,8 @@
 #include "msgpack.hpp"
 // from 3rdparty/xchange: msgpack <-> rapidjson converter
 #include "msgpack/type/rapidjson.hpp"
-#include "msgpack/zbuffer.hpp"
 #include "compression/compression_selector.h"
+#include "dictionary/util/msgpack_util.h"
 
 //#define ENABLE_TRACING
 #include "dictionary/util/trace.h"
@@ -68,7 +68,7 @@ inline std::string DecodeJsonValue(const std::string& encoded_value) {
 inline void EncodeJsonValue(
     std::function<void (compression::buffer_t&, const char*, size_t)> long_compress,
     std::function<void (compression::buffer_t&, const char*, size_t)> short_compress,
-    msgpack::sbuffer& msgpack_buffer,
+    msgpack_buffer& msgpack_buffer,
     compression::buffer_t& buffer,
     const std::string& raw_value, size_t compression_threshold=32) {
   rapidjson::Document json_document;
@@ -101,7 +101,7 @@ inline void EncodeJsonValue(
  */
 inline std::string EncodeJsonValue(const std::string& raw_value,
                                    size_t compression_threshold=32) {
-  msgpack::sbuffer msgpack_buffer;
+  msgpack_buffer msgpack_buffer;
   compression::buffer_t buffer;
 
   EncodeJsonValue(static_cast<void(*) (compression::buffer_t&, const char*, size_t)>(

--- a/keyvi/src/cpp/dictionary/util/msgpack_util.h
+++ b/keyvi/src/cpp/dictionary/util/msgpack_util.h
@@ -1,0 +1,108 @@
+/* * keyvi - A key value store.
+ *
+ * Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * msgpack_util.h
+ *
+ *  Created on: Oct 27, 2016
+ *      Author: hendrik
+ */
+
+#ifndef UTIL_MSGPACK_UTIL_H_
+#define UTIL_MSGPACK_UTIL_H_
+
+#include "msgpack.hpp"
+
+/**
+ * Utility classes for msgpack.
+ *
+ * In particular this implements a way to decide at runtime to use single precision floats when turning json into
+ * msgpack. The trick is to write to use a buffer implementation which name is used for a template specialization
+ * which does the trick.
+ */
+
+namespace keyvi {
+namespace dictionary {
+namespace util {
+
+class msgpack_buffer: public msgpack::sbuffer {
+ public:
+  using msgpack::sbuffer::sbuffer;
+
+  void set_single_precision_float() {
+    single_precision_float_ = true;
+  }
+
+  bool get_single_precision_float() const {
+    return single_precision_float_;
+  }
+
+ private:
+  bool single_precision_float_ = false;
+};
+
+} /* namespace util */
+} /* namespace dictionary */
+} /* namespace keyvi */
+
+namespace msgpack {
+
+/// @cond
+MSGPACK_API_VERSION_NAMESPACE(v1) {
+/// @endcond
+
+
+/**
+ * Specialization to turn doubles into msgpack single or double precision floats based on the setting in the buffer.
+ *
+ * @param d the double to pack
+ * @return the packer instance
+ */
+
+template <>
+inline packer<keyvi::dictionary::util::msgpack_buffer>& packer<keyvi::dictionary::util::msgpack_buffer>::pack_double(double d)
+{
+  // taken from msgpack code
+  if (m_stream.get_single_precision_float()) {
+    union { float f; uint32_t i; } mem;
+    mem.f = d;
+    char buf[5];
+    buf[0] = static_cast<char>(0xcau); _msgpack_store32(&buf[1], mem.i);
+    append_buffer(buf, 5);
+  } else {
+    union { double f; uint64_t i; } mem;
+    mem.f = d;
+    char buf[9];
+    buf[0] = static_cast<char>(0xcbu);
+
+#if defined(TARGET_OS_IPHONE)
+    // ok
+#elif defined(__arm__) && !(__ARM_EABI__) // arm-oabi
+    // https://github.com/msgpack/msgpack-perl/pull/1
+    mem.i = (mem.i & 0xFFFFFFFFUL) << 32UL | (mem.i >> 32UL);
+#endif
+    _msgpack_store64(&buf[1], mem.i);
+    append_buffer(buf, 9);
+  }
+
+  return *this;
+}
+
+}
+}
+
+#endif /* UTIL_MSGPACK_UTIL_H_ */

--- a/keyvi/tests/cpp/dictionary/util/json_value_test.cpp
+++ b/keyvi/tests/cpp/dictionary/util/json_value_test.cpp
@@ -1,0 +1,51 @@
+//
+// keyvi - A key value store.
+//
+// Copyright 2015 Hendrik Muhs<hendrik.muhs@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+ * json_value_test.cpp
+ *
+ *  Created on: Oct 27, 2016
+ *      Author: hendrik
+ */
+
+
+#include <boost/test/unit_test.hpp>
+#include "dictionary/util/json_value.h"
+
+namespace keyvi {
+namespace dictionary {
+namespace util {
+
+BOOST_AUTO_TEST_SUITE( JsonValueTests )
+
+BOOST_AUTO_TEST_CASE( EncodeDecodeTest ) {
+
+  std::string input = "{'auto':'car','price':344,'features':[1,2,3]}";
+  std::string encoded = EncodeJsonValue(input);
+
+  std::string output = DecodeJsonValue(encoded);
+
+  BOOST_CHECK_EQUAL('"' + input + '"', output);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()
+
+} /* namespace util */
+} /* namespace dictionary */
+} /* namespace keyvi */

--- a/pykeyvi/tests/json/json_dictionary_test.py
+++ b/pykeyvi/tests/json/json_dictionary_test.py
@@ -62,4 +62,20 @@ def test_unicode_compile():
         assert d["üüüüüüabd"].GetValueAsString() == '{"a":3}'
         assert d["ääääädäd"].GetValueAsString() == '{"b":33}'
 
+def test_float_compaction():
+    cs = pykeyvi.JsonDictionaryCompiler(50000000, {'floating_point_precision': 'single'})
+    cd = pykeyvi.JsonDictionaryCompiler(50000000)
 
+    # add a couple of floats to both
+    cs.Add('aa', '[1.7008715758978892, 1.8094465532317732, 1.6098250864350536, 1.6369107966501981, 1.7736887965234107, 1.606682751740542, 1.6186427703265525, 1.7939763843449683, 1.5973550162469434, 1.6799721708726192, 1.8199786239525833, 1.7956178070065245, 1.7269879953863045]')
+    cd.Add('aa', '[1.7008715758978892, 1.8094465532317732, 1.6098250864350536, 1.6369107966501981, 1.7736887965234107, 1.606682751740542, 1.6186427703265525, 1.7939763843449683, 1.5973550162469434, 1.6799721708726192, 1.8199786239525833, 1.7956178070065245, 1.7269879953863045]')
+
+    with tmp_dictionary(cs, 'json_single_precision_float.kv') as ds:
+        with tmp_dictionary(cd, 'json_double_precision_float.kv') as dd:
+            # first some basic checks
+            assert len(ds) == 1
+            assert len(dd) == 1
+            # simple test the length of the value store which shall be smaller for single floats
+            stats_s = ds.GetStatistics()
+            stats_d = dd.GetStatistics()
+            assert int(stats_s['Value Store']['size']) < int(stats_d['Value Store']['size'])


### PR DESCRIPTION
implement floating_point_precision option to optionally reduce valuestore size for jsonvaluestore by using single instead of double precision floats