### PR TITLE
fix #201

### DIFF
--- a/keyvi/src/cpp/dictionary/fsa/generator.h
+++ b/keyvi/src/cpp/dictionary/fsa/generator.h
@@ -162,7 +162,7 @@ final {
         : memory_limit_(memory_limit), params_(params) {
 
       // use 50% or limit minus 200MB for the memory limit of the hashtable
-      size_t memory_limit_minimization =
+      const size_t memory_limit_minimization =
           memory_limit > (400 * 1024 * 1024) ?
               memory_limit - (200 * 1024 * 1024) :
               memory_limit / 2;

--- a/keyvi/src/cpp/dictionary/fsa/generator.h
+++ b/keyvi/src/cpp/dictionary/fsa/generator.h
@@ -162,8 +162,10 @@ final {
         : memory_limit_(memory_limit), params_(params) {
 
       // use 50% or limit minus 200MB for the memory limit of the hashtable
-      size_t memory_limit_minimization = std::max(
-          memory_limit / 2, memory_limit - (200 * 1024 * 1024));
+      size_t memory_limit_minimization =
+          memory_limit > (400 * 1024 * 1024) ?
+              memory_limit - (200 * 1024 * 1024) :
+              memory_limit / 2;
 
       if (params_.count(TEMPORARY_PATH_KEY) == 0) {
         params_[TEMPORARY_PATH_KEY] =


### PR DESCRIPTION
For memory limits < 200MB the old implementation caused an underflow, ending in wrong memory calculation.

@narekgharibyan 