### PR TITLE
add a simple test for int dictionaries

### DIFF
--- a/pykeyvi/src/addons/IntDictionaryCompiler.pyx
+++ b/pykeyvi/src/addons/IntDictionaryCompiler.pyx
@@ -1,0 +1,24 @@
+
+
+    def __enter__(self):
+        return self
+
+
+    def __exit__(self, type, value, traceback):
+        self.Compile()
+
+
+    def Compile(self, *args):
+        if not args:
+            with nogil:
+                self.inst.get().Compile()
+            return
+
+        cdef void* callback = <void*> args[0]
+        with nogil:
+            self.inst.get().Compile(callback_wrapper, callback)
+
+
+    def SetManifest(self, manifest):
+        m = json.dumps(manifest).encode('utf-8')
+        self.inst.get().SetManifestFromString(m)

--- a/pykeyvi/tests/int/int_dictionary_test.py
+++ b/pykeyvi/tests/int/int_dictionary_test.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Usage: py.test tests
+
+import os
+import tempfile
+import pykeyvi
+from test_tools import tmp_dictionary
+
+
+def test_manifest():
+    c = pykeyvi.IntDictionaryCompiler({"memory_limit_mb":"10"})
+    c.Add("Leela", 20)
+    c.Add("Kif", 2)
+    c.SetManifest({"drink": "slurm"})
+    with tmp_dictionary(c, 'slurm.kv') as d:
+        m = d.GetManifest()
+        assert m['drink'] == "slurm"


### PR DESCRIPTION
I realized that I forgot to check in 1 file when separating completion and int dictionary.

Unfortunately this was not catched as it is part of code generation and it works without the file. So I added a test that should trigger the problem. If I am right CI on this 1st commit should fail.