### PR TITLE
Added compiler params support in keyvi cli

### DIFF
--- a/pykeyvi/keyvicli/cli.py
+++ b/pykeyvi/keyvicli/cli.py
@@ -25,7 +25,7 @@ def dump(args):
 
 
 def compile(args):
-    params = {key: value for key, value in args.compiler_options}
+    params = {key: value for key, value in args.compiler_params}
 
     dict_type = args.dict_type
     if dict_type == 'json':
@@ -69,9 +69,9 @@ def main():
     compile_parser.add_argument('output_file', type=str, metavar='OUT_FILE')
     compile_parser.add_argument('dict_type', type=str, choices=['json', 'key-only'],
                                 help='dictionary type')
-    compile_parser.add_argument('--option', action='append', default=[], dest='compiler_options',
+    compile_parser.add_argument('--param', action='append', default=[], dest='compiler_params',
                                 type=lambda kv: kv.split("="),
-                                help='options for keyvi compiler in format option=value')
+                                help='parameters for keyvi compiler in format param=value')
 
     args = argument_parser.parse_args()
 

--- a/pykeyvi/keyvicli/cli.py
+++ b/pykeyvi/keyvicli/cli.py
@@ -3,6 +3,8 @@ import pykeyvi
 
 from argparse import ArgumentParser
 
+GB = 1024 * 1024 * 1024
+
 
 def stats(input_file):
     print (json.dumps(pykeyvi.Dictionary(input_file).GetStatistics(), indent=4, sort_keys=True))
@@ -23,11 +25,13 @@ def dump(args):
 
 
 def compile(args):
+    params = {key: value for key, value in args.compiler_options}
+
     dict_type = args.dict_type
     if dict_type == 'json':
-        dictionary = pykeyvi.JsonDictionaryCompiler()
+        dictionary = pykeyvi.JsonDictionaryCompiler(GB, params)
     elif dict_type == 'key-only':
-        dictionary = pykeyvi.KeyOnlyDictionaryCompiler()
+        dictionary = pykeyvi.KeyOnlyDictionaryCompiler(GB, params)
     else:
         return 'Must never reach here'
 
@@ -65,6 +69,9 @@ def main():
     compile_parser.add_argument('output_file', type=str, metavar='OUT_FILE')
     compile_parser.add_argument('dict_type', type=str, choices=['json', 'key-only'],
                                 help='dictionary type')
+    compile_parser.add_argument('--option', action='append', default=[], dest='compiler_options',
+                                type=lambda kv: kv.split("="),
+                                help='options for keyvi compiler in format option=value')
 
     args = argument_parser.parse_args()
 


### PR DESCRIPTION
@hendrikmuhs 

Fixes #214 
Decided do not expose `memory_limit` param for now and  use default to avoid backward compatibility issue later on.
