### PR TITLE
Throw exception when compiler is used in a wrong fashion: calling write without prior compile.

### DIFF
--- a/keyvi/src/cpp/dictionary/dictionary_compiler.h
+++ b/keyvi/src/cpp/dictionary/dictionary_compiler.h
@@ -252,11 +252,19 @@ class DictionaryCompiler
     }
 
     void Write(std::ostream& stream) {
-       generator_->Write(stream);
+      if (!generator_) {
+        throw compiler_exception("not compiled yet");
+      }
+
+      generator_->Write(stream);
     }
 
     template<typename StringType>
     void WriteToFile(StringType filename) {
+      if (!generator_) {
+        throw compiler_exception("not compiled yet");
+      }
+
       std::ofstream out_stream(filename, std::ios::binary);
       generator_->Write(out_stream);
       out_stream.close();

--- a/pykeyvi/src/pxds/dictionary_compiler.pxd
+++ b/pykeyvi/src/pxds/dictionary_compiler.pxd
@@ -14,7 +14,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
-        void WriteToFile(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +
         
     cdef cppclass KeyOnlyDictionaryCompiler:
         KeyOnlyDictionaryCompiler() except +
@@ -24,7 +24,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
-        void WriteToFile(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +
         
     cdef cppclass JsonDictionaryCompiler:
         JsonDictionaryCompiler() except +
@@ -35,7 +35,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifestFromString(libcpp_utf8_string) except + # wrap-ignore
-        void WriteToFile(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +
     
     cdef cppclass JsonDictionaryCompilerSmallData:
         JsonDictionaryCompilerSmallData() except +
@@ -46,7 +46,7 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifestFromString(libcpp_utf8_string) except + # wrap-ignore
-        void WriteToFile(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +
         
     cdef cppclass StringDictionaryCompiler:
         StringDictionaryCompiler() except +
@@ -57,5 +57,5 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Compile() nogil # wrap-ignore
         void Compile(callback_t, void*) nogil # wrap-ignore
         void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
-        void WriteToFile(libcpp_utf8_string)
+        void WriteToFile(libcpp_utf8_string) except +
 

--- a/pykeyvi/tests/dictionary_compiler_test.py
+++ b/pykeyvi/tests/dictionary_compiler_test.py
@@ -6,7 +6,7 @@ import pykeyvi
 import shutil
 import tempfile
 import test_tools
-
+from pytest import raises
 
 def test_compiler_no_compile_edge_case():
     c = pykeyvi.KeyOnlyDictionaryCompiler()
@@ -63,3 +63,11 @@ def test_tmp_dir_defined():
     finally:
         pykeyvi.JsonDictionaryCompiler()
         shutil.rmtree(test_dir)
+
+
+def test_compile_step_missing():
+    c = pykeyvi.KeyOnlyDictionaryCompiler()
+    c.Add("abc")
+    c.Add("abd")
+    with raises(RuntimeError):
+        c.WriteToFile("compile_step_missing.kv")


### PR DESCRIPTION
fixes #225