### PR TITLE
Fix CLI dump not working in py3

### DIFF
--- a/pykeyvi/keyvicli/cli.py
+++ b/pykeyvi/keyvicli/cli.py
@@ -14,6 +14,8 @@ def dump(args):
         for key, value in dictionary.GetAllItems():
             if args.json_dumps:
                 key = json.dumps(key)
+            if isinstance(key, bytes):
+                key = key.decode()
             file_out.write(key)
             if value:
                 if args.json_dumps:


### PR DESCRIPTION
dump() was not working in py3 because file object cannot write() a bytes object. Fix: decode bytes object to string before write()ing