### PR TITLE
New dictionary mergers + CLI enhancements

### DIFF
--- a/keyvi/src/cpp/dictionary/dictionary_types.h
+++ b/keyvi/src/cpp/dictionary/dictionary_types.h
@@ -81,6 +81,9 @@ typedef keyvi::dictionary::DictionaryMerger<
         keyvi::dictionary::fsa::internal::SparseArrayPersistence<uint16_t>,
         keyvi::dictionary::fsa::internal::StringValueStore> StringDictionaryMerger;
 
+typedef keyvi::dictionary::DictionaryMerger<
+        keyvi::dictionary::fsa::internal::SparseArrayPersistence<uint16_t>> KeyOnlyDictionaryMerger;
+
 
 } /* namespace dictionary */
 } /* namespace keyvi */

--- a/keyvi/src/cpp/dictionary/dictionary_types.h
+++ b/keyvi/src/cpp/dictionary/dictionary_types.h
@@ -77,6 +77,10 @@ typedef keyvi::dictionary::DictionaryMerger<
         keyvi::dictionary::fsa::internal::IntValueStore> IntDictionaryMerger;
 
 
+typedef keyvi::dictionary::DictionaryMerger<
+        keyvi::dictionary::fsa::internal::SparseArrayPersistence<uint16_t>,
+        keyvi::dictionary::fsa::internal::StringValueStore> StringDictionaryMerger;
+
 
 } /* namespace dictionary */
 } /* namespace keyvi */

--- a/keyvi/src/cpp/dictionary/fsa/internal/int_inner_weights_value_store.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/int_inner_weights_value_store.h
@@ -63,6 +63,10 @@ class IntInnerWeightsValueStore final : public IValueStoreWriter {
     return value;
   }
 
+  uint64_t GetMergeValueId(size_t fileIndex, uint64_t oldIndex) {
+    return oldIndex;
+  }
+
   uint32_t GetMergeWeight(uint64_t fsa_value){
     return fsa_value;
   }

--- a/keyvi/src/cpp/dictionary/fsa/internal/int_value_store.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/int_value_store.h
@@ -59,6 +59,10 @@ class IntValueStore final : public IValueStoreWriter {
     return value;
   }
 
+  uint64_t GetMergeValueId(size_t fileIndex, uint64_t oldIndex) {
+    return oldIndex;
+  }
+
   uint32_t GetWeightValue(value_t value) const {
     return 0;
   }

--- a/keyvi/tests/cpp/dictionary/dictionary_merger_test.cpp
+++ b/keyvi/tests/cpp/dictionary/dictionary_merger_test.cpp
@@ -210,6 +210,87 @@ BOOST_AUTO_TEST_CASE ( MergeIntegerDictsValueMerge) {
   std::remove(filename.c_str());
 }
 
+BOOST_AUTO_TEST_CASE ( MergeIntegerDictsAppendMerge) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+          { "abc", 22 },
+          { "abbc", 24 }
+  };
+  testing::TempDictionary dictionary (test_data, false);
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+          { "abc", 25 },
+          { "abbc", 42 },
+          { "abcd", 21 },
+          { "abbc", 30 },
+  };
+  testing::TempDictionary dictionary2 (test_data2, false);
+
+  std::string filename ("merged-dict-int-v1.kv");
+  IntDictionaryMerger merger(merger_param_t({{"memory_limit_mb","10"}, {"merge_mode","append"}}));
+  merger.Add(dictionary.GetFileName());
+  merger.Add(dictionary2.GetFileName());
+
+  merger.Merge(filename);
+
+  fsa::automata_t fsa(new fsa::Automata(filename.c_str()));
+  dictionary_t d(new Dictionary(fsa));
+
+  BOOST_CHECK(d->Contains("abc"));
+  BOOST_CHECK(d->Contains("abbc"));
+  BOOST_CHECK(d->Contains("abcd"));
+
+  BOOST_CHECK_EQUAL("25", d->operator[]("abc").GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d->operator[]("abcd").GetValueAsString());
+  BOOST_CHECK_EQUAL("30", d->operator[]("abbc").GetValueAsString());
+
+  std::remove(filename.c_str());
+
+  filename = "merged-dict-int-v2.kv";
+  testing::TempDictionary dictionary3(test_data, false);
+  IntDictionaryMerger merger2(merger_param_t({{"memory_limit_mb","10"}, {"merge_mode","append"}}));
+  merger2.Add(dictionary.GetFileName());
+  merger2.Add(dictionary2.GetFileName());
+  merger2.Add(dictionary3.GetFileName());
+
+  merger2.Merge(filename);
+
+  fsa::automata_t fsa2(new fsa::Automata(filename.c_str()));
+  dictionary_t d2(new Dictionary(fsa2));
+
+  BOOST_CHECK(d2->Contains("abc"));
+  BOOST_CHECK(d2->Contains("abbc"));
+  BOOST_CHECK(d2->Contains("abcd"));
+
+  BOOST_CHECK_EQUAL("22", d2->operator[]("abc").GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd").GetValueAsString());
+
+  // overwritten by 2nd
+  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc").GetValueAsString());
+
+  std::remove(filename.c_str());
+
+  filename = "merged-dict-int-v3.kv";
+  IntDictionaryMerger merger3(merger_param_t({{"memory_limit_mb","10"}, {"merge_mode","append"}}));
+
+  merger3.Add(dictionary2.GetFileName());
+  merger3.Add(dictionary.GetFileName());
+
+  merger3.Merge(filename);
+
+  fsa::automata_t fsa3(new fsa::Automata(filename.c_str()));
+  dictionary_t d3(new Dictionary(fsa3));
+
+  BOOST_CHECK(d3->Contains("abc"));
+  BOOST_CHECK(d3->Contains("abbc"));
+  BOOST_CHECK(d3->Contains("abcd"));
+
+  BOOST_CHECK_EQUAL("22", d3->operator[]("abc").GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d3->operator[]("abcd").GetValueAsString());
+  BOOST_CHECK_EQUAL("24", d3->operator[]("abbc").GetValueAsString());
+
+  std::remove(filename.c_str());
+}
+
 
 BOOST_AUTO_TEST_CASE ( MergeStringDicts) {
   std::vector<std::pair<std::string, std::string>> test_data = {
@@ -482,6 +563,48 @@ BOOST_AUTO_TEST_CASE ( MergeIntegerWeightDictsValueMerge) {
 
   std::remove(filename.c_str());
 }
+
+
+BOOST_AUTO_TEST_CASE ( MergeIntegerWeightDictsAppendMerge) {
+  std::vector<std::pair<std::string, uint32_t>> test_data = {
+          { "abc", 22 },
+          { "abbc", 24 }
+  };
+  testing::TempDictionary dictionary (test_data);
+
+  std::vector<std::pair<std::string, uint32_t>> test_data2 = {
+          { "abc", 25 },
+          { "abbc", 42 },
+          { "abcd", 21 },
+          { "abbc", 30 },
+  };
+  testing::TempDictionary dictionary2 (test_data2);
+
+  std::string filename = "merged-dict-int-weight-v2.kv";
+  testing::TempDictionary dictionary3(test_data);
+  CompletionDictionaryMerger merger2(merger_param_t({{"memory_limit_mb","10"}, {"merge_mode", "append"}}));
+  merger2.Add(dictionary.GetFileName());
+  merger2.Add(dictionary2.GetFileName());
+  merger2.Add(dictionary3.GetFileName());
+
+  merger2.Merge(filename);
+
+  fsa::automata_t fsa2(new fsa::Automata(filename.c_str()));
+  dictionary_t d2(new Dictionary(fsa2));
+
+  BOOST_CHECK(d2->Contains("abc"));
+  BOOST_CHECK(d2->Contains("abbc"));
+  BOOST_CHECK(d2->Contains("abcd"));
+
+  BOOST_CHECK_EQUAL("22", d2->operator[]("abc").GetValueAsString());
+  BOOST_CHECK_EQUAL("21", d2->operator[]("abcd").GetValueAsString());
+
+  // overwritten by 2nd
+  BOOST_CHECK_EQUAL("24", d2->operator[]("abbc").GetValueAsString());
+
+  std::remove(filename.c_str());
+}
+
 
 BOOST_AUTO_TEST_CASE (MergeToEmptyDict) {
     std::vector<std::pair<std::string, std::string>> test_data = {};

--- a/pykeyvi/keyvicli/cli.py
+++ b/pykeyvi/keyvicli/cli.py
@@ -30,6 +30,8 @@ def compile(args):
     dict_type = args.dict_type
     if dict_type == 'json':
         dictionary = pykeyvi.JsonDictionaryCompiler(params)
+    elif dict_type == 'string':
+        dictionary = pykeyvi.StringDictionaryCompiler(params)
     elif dict_type == 'key-only':
         dictionary = pykeyvi.KeyOnlyDictionaryCompiler(params)
     else:
@@ -67,7 +69,7 @@ def main():
     compile_parser = subparsers.add_parser('compile')
     compile_parser.add_argument('input_file', type=str, metavar='FILE')
     compile_parser.add_argument('output_file', type=str, metavar='OUT_FILE')
-    compile_parser.add_argument('dict_type', type=str, choices=['json', 'key-only'],
+    compile_parser.add_argument('dict_type', type=str, choices=['json', 'string', 'key-only'],
                                 help='dictionary type')
     compile_parser.add_argument('--param', action='append', default=[], dest='compiler_params',
                                 type=lambda kv: kv.split("="),

--- a/pykeyvi/keyvicli/cli.py
+++ b/pykeyvi/keyvicli/cli.py
@@ -32,6 +32,10 @@ def compile(args):
         dictionary = pykeyvi.JsonDictionaryCompiler(params)
     elif dict_type == 'string':
         dictionary = pykeyvi.StringDictionaryCompiler(params)
+    elif dict_type == 'int':
+        dictionary = pykeyvi.IntDictionaryCompiler(params)
+    elif dict_type == 'completion':
+        dictionary = pykeyvi.CompletionDictionaryCompiler(params)
     elif dict_type == 'key-only':
         dictionary = pykeyvi.KeyOnlyDictionaryCompiler(params)
     else:
@@ -44,6 +48,8 @@ def compile(args):
                 splits = line.split('\t')
                 if dict_type == 'key-only':
                     dictionary.Add(splits[0])
+                elif dict_type == 'int' or dict_type == 'completion':
+                    dictionary.Add(splits[0], int(splits[1]))
                 else:
                     dictionary.Add(splits[0], splits[1])
             except:
@@ -61,6 +67,10 @@ def merge(args):
         merger = pykeyvi.JsonDictionaryMerger(params)
     elif dict_type == 'string':
         merger = pykeyvi.StringDictionaryMerger(params)
+    elif dict_type == 'int':
+        merger = pykeyvi.IntDictionaryMerger(params)
+    elif dict_type == 'completion':
+        merger = pykeyvi.CompletionDictionaryMerger(params)
     elif dict_type == 'key-only':
         merger = pykeyvi.KeyOnlyDictionaryMerger(params)
     else:
@@ -88,7 +98,7 @@ def main():
     compile_parser = subparsers.add_parser('compile')
     compile_parser.add_argument('input_file', type=str, metavar='FILE')
     compile_parser.add_argument('output_file', type=str, metavar='OUT_FILE')
-    compile_parser.add_argument('dict_type', type=str, choices=['json', 'string', 'key-only'],
+    compile_parser.add_argument('dict_type', type=str, choices=['json', 'string', 'int', 'completion', 'key-only'],
                                 help='dictionary type')
     compile_parser.add_argument('--param', action='append', default=[], dest='compiler_params',
                                 type=lambda kv: kv.split("="),
@@ -97,7 +107,7 @@ def main():
     merge_parser = subparsers.add_parser('merge')
     merge_parser.add_argument('-i', '--input-files', nargs='+', dest='input_files', required=True)
     merge_parser.add_argument('-o', '--output-file', type=str, required=True)
-    merge_parser.add_argument('dict_type', type=str, choices=['json', 'string', 'key-only'],
+    merge_parser.add_argument('dict_type', type=str, choices=['json', 'string', 'int', 'completion', 'key-only'],
                               help='dictionary type')
     merge_parser.add_argument('--param', action='append', default=[], dest='merger_params',
                               type=lambda kv: kv.split("="),

--- a/pykeyvi/setup.py
+++ b/pykeyvi/setup.py
@@ -173,6 +173,10 @@ with symlink_keyvi() as (pykeyvi_source_path, keyvi_source_path):
                     os.makedirs(mac_os_static_libs_dir)
 
                 for lib in linklibraries_static_or_dynamic:
+                    # workaround: temp disabled static link with snappy:
+                    # see: https://github.com/Homebrew/homebrew-core/issues/15722
+                    if lib == 'snappy':
+                        continue
                     lib_file_name = 'lib{}.a'.format(lib)
                     src_file = path.join('/usr/local/lib', lib_file_name)
                     dst_file = path.join(mac_os_static_libs_dir, lib_file_name)

--- a/pykeyvi/src/addons/IntDictionaryMerger.pyx
+++ b/pykeyvi/src/addons/IntDictionaryMerger.pyx
@@ -1,0 +1,5 @@
+
+
+    def SetManifest(self, manifest):
+        m = json.dumps(manifest).encode('utf-8')
+        self.inst.get().SetManifestFromString(m)

--- a/pykeyvi/src/addons/KeyOnlyDictionaryMerger.pyx
+++ b/pykeyvi/src/addons/KeyOnlyDictionaryMerger.pyx
@@ -1,0 +1,5 @@
+
+
+    def SetManifest(self, manifest):
+        m = json.dumps(manifest).encode('utf-8')
+        self.inst.get().SetManifestFromString(m)

--- a/pykeyvi/src/addons/StringDictionaryMerger.pyx
+++ b/pykeyvi/src/addons/StringDictionaryMerger.pyx
@@ -1,0 +1,5 @@
+
+
+    def SetManifest(self, manifest):
+        m = json.dumps(manifest).encode('utf-8')
+        self.inst.get().SetManifestFromString(m)

--- a/pykeyvi/src/pxds/dictionary_merger.pxd
+++ b/pykeyvi/src/pxds/dictionary_merger.pxd
@@ -44,3 +44,13 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Add(libcpp_utf8_string) except +
         void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
+
+cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
+    cdef cppclass IntDictionaryMerger:
+        IntDictionaryMerger() except +
+        IntDictionaryMerger(size_t memory_limit) except + # DEPRECATED
+        IntDictionaryMerger(size_t memory_limit, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except + # DEPRECATED
+        IntDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string) except +
+        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void Merge(libcpp_utf8_string) nogil

--- a/pykeyvi/src/pxds/dictionary_merger.pxd
+++ b/pykeyvi/src/pxds/dictionary_merger.pxd
@@ -34,3 +34,13 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Add(libcpp_utf8_string) except +
         void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
+
+cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
+    cdef cppclass KeyOnlyDictionaryMerger:
+        KeyOnlyDictionaryMerger() except +
+        KeyOnlyDictionaryMerger(size_t memory_limit) except + # DEPRECATED
+        KeyOnlyDictionaryMerger(size_t memory_limit, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except + # DEPRECATED
+        KeyOnlyDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string) except +
+        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void Merge(libcpp_utf8_string) nogil

--- a/pykeyvi/src/pxds/dictionary_merger.pxd
+++ b/pykeyvi/src/pxds/dictionary_merger.pxd
@@ -24,3 +24,13 @@ cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
         void Add(libcpp_utf8_string) except +
         void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
         void Merge(libcpp_utf8_string) nogil
+
+cdef extern from "dictionary/dictionary_types.h" namespace "keyvi::dictionary":
+    cdef cppclass StringDictionaryMerger:
+        StringDictionaryMerger() except +
+        StringDictionaryMerger(size_t memory_limit) except + # DEPRECATED
+        StringDictionaryMerger(size_t memory_limit, libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except + # DEPRECATED
+        StringDictionaryMerger(libcpp_map[libcpp_utf8_string, libcpp_utf8_string] value_store_params) except +
+        void Add(libcpp_utf8_string) except +
+        void SetManifestFromString(libcpp_utf8_string) # wrap-ignore
+        void Merge(libcpp_utf8_string) nogil

--- a/pykeyvi/tests/dictionary/int_dictionary_merger_test.py
+++ b/pykeyvi/tests/dictionary/int_dictionary_merger_test.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+# Usage: py.test tests
+
+import pykeyvi
+
+import sys
+import os
+import tempfile
+import shutil
+import collections
+import pytest
+
+from os import path
+
+root = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(root, "../"))
+
+from test_tools import decode_to_unicode
+
+key_values_1 = {
+    'a': 12,
+    'bzzzz': 34,
+    'bbb': 34,
+    'b': 34
+}
+
+key_values_2 = {
+    'a': 78,
+    'c': 5,
+    'i': 5,
+    'ia': 5,
+    'd': 6
+}
+
+key_values_3 = {
+    'e': 76,
+    'd': 356,
+    'e1': 76,
+    'e2': 76,
+    'e3': 76,
+    'e4': 76,
+    'f': 9
+}
+
+
+def generate_keyvi(key_values, filename):
+    dictionary_compiler = pykeyvi.IntDictionaryCompiler({"memory_limit_mb": "10"})
+    for key, value in key_values.items():
+        dictionary_compiler.Add(key, value)
+
+    dictionary_compiler.Compile()
+    dictionary_compiler.WriteToFile(filename)
+
+
+@pytest.mark.parametrize('merger', [pykeyvi.IntDictionaryMerger({"memory_limit_mb": "10"}),
+                                    pykeyvi.IntDictionaryMerger({"memory_limit_mb": "10", 'merge_mode': 'append'})
+                                    ])
+def test_merge(merger):
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        file_1 = path.join(tmp_dir, 'test_merger_1.kv')
+        file_2 = path.join(tmp_dir, 'test_merger_2.kv')
+        file_3 = path.join(tmp_dir, 'test_merger_3.kv')
+        merge_file = path.join(tmp_dir, 'merge.kv')
+
+        generate_keyvi(key_values_1, file_1)
+        generate_keyvi(key_values_2, file_2)
+        generate_keyvi(key_values_3, file_3)
+
+        merger.Add(file_1)
+        merger.Add(file_2)
+        merger.Add(file_3)
+        merger.Merge(merge_file)
+
+        merged_dictionary = pykeyvi.Dictionary(merge_file)
+
+        key_values = {}
+        key_values.update(key_values_1)
+        key_values.update(key_values_2)
+        key_values.update(key_values_3)
+
+        key_values_ordered = collections.OrderedDict(sorted(key_values.items()))
+
+        for (base_key, base_value), (keyvi_key, keyvi_value) in zip(key_values_ordered.items(),
+                                                                    merged_dictionary.GetAllItems()):
+            assert decode_to_unicode(base_key) == decode_to_unicode(keyvi_key)
+            assert base_value == keyvi_value
+
+    finally:
+        shutil.rmtree(tmp_dir)

--- a/pykeyvi/tests/dictionary/key_only_dictionary_merger_test.py
+++ b/pykeyvi/tests/dictionary/key_only_dictionary_merger_test.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Usage: py.test tests
+
+import pykeyvi
+
+import sys
+import os
+import json
+import tempfile
+import shutil
+import collections
+import pytest
+
+from os import path
+
+root = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(root, "../"))
+
+from test_tools import decode_to_unicode
+
+keys_1 = {
+    'a',
+    'bzzzz',
+    'bbb',
+    'b'
+}
+
+keys_2 = {
+    'a',
+    'c',
+    'i',
+    'ia',
+    'd'
+}
+
+keys_3 = {
+    'e',
+    'd',
+    'e1',
+    'e2',
+    'e3',
+    'e4',
+    'f'
+}
+
+
+def generate_keyvi(key_values, filename):
+    dictionary_compiler = pykeyvi.KeyOnlyDictionaryCompiler({"memory_limit_mb": "10"})
+    for key in key_values:
+        dictionary_compiler.Add(key)
+
+    dictionary_compiler.Compile()
+    dictionary_compiler.WriteToFile(filename)
+
+
+@pytest.mark.parametrize('merger', [pykeyvi.KeyOnlyDictionaryMerger({"memory_limit_mb": "10"}),
+                                    pykeyvi.KeyOnlyDictionaryMerger({"memory_limit_mb": "10", 'merge_mode': 'append'})])
+def test_merge(merger):
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        file_1 = path.join(tmp_dir, 'test_merger_1.kv')
+        file_2 = path.join(tmp_dir, 'test_merger_2.kv')
+        file_3 = path.join(tmp_dir, 'test_merger_3.kv')
+        merge_file = path.join(tmp_dir, 'merge.kv')
+
+        generate_keyvi(keys_1, file_1)
+        generate_keyvi(keys_2, file_2)
+        generate_keyvi(keys_3, file_3)
+
+        merger.Add(file_1)
+        merger.Add(file_2)
+        merger.Add(file_3)
+        merger.Merge(merge_file)
+
+        merged_dictionary = pykeyvi.Dictionary(merge_file)
+
+        keys = set()
+        keys.update(keys_1)
+        keys.update(keys_2)
+        keys.update(keys_3)
+
+        keys_ordered = sorted(keys)
+
+        for base_key, keyvi_key in zip(keys_ordered, merged_dictionary.GetAllKeys()):
+            assert decode_to_unicode(base_key) == decode_to_unicode(keyvi_key)
+
+    finally:
+        shutil.rmtree(tmp_dir)

--- a/pykeyvi/tests/dictionary/string_dictionary_merger_test.py
+++ b/pykeyvi/tests/dictionary/string_dictionary_merger_test.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# Usage: py.test tests
+
+import pykeyvi
+
+import sys
+import os
+import json
+import tempfile
+import shutil
+import collections
+import pytest
+
+from os import path
+
+root = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(root, "../"))
+
+from test_tools import decode_to_unicode
+
+key_values_1 = {
+    'a': "a",
+    'bzzzz': "b",
+    'bbb': "b",
+    'b': "b"
+}
+
+key_values_2 = {
+    'a': "ab",
+    'c': "c",
+    'i': "c",
+    'ia': "c",
+    'd': "d"
+}
+
+key_values_3 = {
+    'e': "e",
+    'd': "dddd",
+    'e1': "e",
+    'e2': "e",
+    'e3': "e",
+    'e4': "e",
+    'f': "f"
+}
+
+
+def generate_keyvi(key_values, filename):
+    dictionary_compiler = pykeyvi.StringDictionaryCompiler({"memory_limit_mb": "10"})
+    for key, value in key_values.items():
+        dictionary_compiler.Add(key, json.dumps(value))
+
+    dictionary_compiler.Compile()
+    dictionary_compiler.WriteToFile(filename)
+
+
+@pytest.mark.parametrize('merger', [pykeyvi.StringDictionaryMerger({"memory_limit_mb": "10"}),
+                                    # pykeyvi.StringDictionaryMerger({"memory_limit_mb": "10", 'merge_mode': 'append'})
+                                    ])
+def test_merge(merger):
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        file_1 = path.join(tmp_dir, 'test_merger_1.kv')
+        file_2 = path.join(tmp_dir, 'test_merger_2.kv')
+        file_3 = path.join(tmp_dir, 'test_merger_3.kv')
+        merge_file = path.join(tmp_dir, 'merge.kv')
+
+        generate_keyvi(key_values_1, file_1)
+        generate_keyvi(key_values_2, file_2)
+        generate_keyvi(key_values_3, file_3)
+
+        merger.Add(file_1)
+        merger.Add(file_2)
+        merger.Add(file_3)
+        merger.Merge(merge_file)
+
+        merged_dictionary = pykeyvi.Dictionary(merge_file)
+
+        key_values = {}
+        key_values.update(key_values_1)
+        key_values.update(key_values_2)
+        key_values.update(key_values_3)
+
+        key_values_ordered = collections.OrderedDict(sorted(key_values.items()))
+
+        for (base_key, base_value), (keyvi_key, keyvi_value) in zip(key_values_ordered.items(),
+                                                                    merged_dictionary.GetAllItems()):
+            assert decode_to_unicode(base_key) == decode_to_unicode(keyvi_key)
+            assert decode_to_unicode(base_value) == decode_to_unicode(keyvi_value)
+
+    finally:
+        shutil.rmtree(tmp_dir)


### PR DESCRIPTION
- added `keyvi merge` subcommand to `keyvi cli`
- added `int, string, completion` dictionaaries support to  `keyvi compile command` 
- added python bindings for `StringDictionaryMerger, KeyOnlyDictionaryMerger, IntDictionaryMerger` types
- added `append_merge` support for `Int` and `Completion` dictionary mergers
- temp disabled static linking with `libsnappy.a` on OSX, see  https://github.com/Homebrew/homebrew-core/issues/15722

@hendrikmuhs 