### PR TITLE
Thread-safe dictionary load

### DIFF
--- a/keyvi/src/cpp/dictionary/fsa/internal/serialization_utils.h
+++ b/keyvi/src/cpp/dictionary/fsa/internal/serialization_utils.h
@@ -26,6 +26,8 @@
 #define SERIALIZATION_UTILS_H_
 
 #include <arpa/inet.h>
+// boost json parser depends on boost::spirit, and spirit is not thread-safe by default. so need to enable thread-safety
+#define BOOST_SPIRIT_THREADSAFE
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
Boost json parser depends on `boost::spirit`, and spirit is not thread-safe by default. so need to enable thread-safety.

Note: Unfortunately I didn't manage to find an easy way to add unit test using boost::tests, but it was tested manually using 5000 concurrent threads.
